### PR TITLE
Accept also bytearray type for message payload

### DIFF
--- a/pylgbst/messages.py
+++ b/pylgbst/messages.py
@@ -58,7 +58,7 @@ class UpstreamMsg(Message):
         assert hub_id == 0
         msg_type = msg._byte()
         assert cls.TYPE == msg_type, "Message type does not match: %x!=%x" % (cls.TYPE, msg_type)
-        assert isinstance(msg.payload, bytes)
+        assert isinstance(msg.payload, (bytes, bytearray))
         return msg
 
     def __shift(self, vtype, vlen):

--- a/pylgbst/utilities.py
+++ b/pylgbst/utilities.py
@@ -30,7 +30,7 @@ def usint(seq, index):
 def str2hex(data):  # we need it for python 2+3 compatibility
     # if sys.version_info[0] == 3:
     # data = bytes(data, 'ascii')
-    if not isinstance(data, bytes):
+    if not isinstance(data, (bytes, bytearray)):
         data = bytes(data, 'ascii')
     hexed = binascii.hexlify(data)
     return hexed


### PR DESCRIPTION
Running the demo with Python 3.7.3 (on Fedora 30) failed with assertion errors on the upstream message payload -- the code expected `bytes` but the actual class was `bytearray`: Since these two data types should be interchangeable mostly, adding `bytearray` to the offending assertions seems to enough to fix the issue.