### PR TITLE
Introduce driver that works with Bleak

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,13 @@ addons:
       - python-gi
       - python3-dbus
       - python3-gi
+      - bluez
 install:
   - wget https://github.com/labapart/gattlib/releases/download/dev/gattlib_dbus_0.2-dev_x86_64.deb
   - sudo dpkg -i gattlib_dbus_0.2-dev_x86_64.deb
   - pip install codecov codacy-coverage nose-exclude pygatt gatt pexpect bluepy
+  - pip install --upgrade attrs
+  - pip install bleak
 
 
 script:

--- a/pylgbst/__init__.py
+++ b/pylgbst/__init__.py
@@ -38,6 +38,13 @@ def get_connection_bluepy(controller='hci0', hub_mac=None):
 
 
 def get_connection_bleak(controller='hci0', hub_mac=None):
+    """
+    Returns connection based with Bleak API as an endpoint.
+    :param controller: Not used, kept for compatibility with others.
+    :param hub_mac: Optional Lego HUB MAC to connect to.
+    :return: Driver object.
+    """
+    del controller  # to prevent code analysis warning
     from pylgbst.comms.cbleak import BleakDriver
 
     return BleakDriver(hub_mac)

--- a/pylgbst/__init__.py
+++ b/pylgbst/__init__.py
@@ -39,7 +39,8 @@ def get_connection_bluepy(controller='hci0', hub_mac=None):
 
 def get_connection_bleak(controller='hci0', hub_mac=None):
     """
-    Returns connection based with Bleak API as an endpoint.
+    Return connection based with Bleak API as an endpoint.
+
     :param controller: Not used, kept for compatibility with others.
     :param hub_mac: Optional Lego HUB MAC to connect to.
     :return: Driver object.

--- a/pylgbst/__init__.py
+++ b/pylgbst/__init__.py
@@ -37,6 +37,12 @@ def get_connection_bluepy(controller='hci0', hub_mac=None):
     return BluepyConnection(controller).connect(hub_mac)
 
 
+def get_connection_bleak(controller='hci0', hub_mac=None):
+    from pylgbst.comms.cbleak import BleakDriver
+
+    return BleakDriver(hub_mac)
+
+
 def get_connection_auto(controller='hci0', hub_mac=None):
     fns = [
         get_connection_bluepy,
@@ -44,6 +50,7 @@ def get_connection_auto(controller='hci0', hub_mac=None):
         get_connection_gatt,
         get_connection_gattool,
         get_connection_gattlib,
+        get_connection_bleak,
     ]
 
     conn = None

--- a/pylgbst/comms/cbleak.py
+++ b/pylgbst/comms/cbleak.py
@@ -4,7 +4,7 @@ import queue
 import threading
 import time
 
-from pylgbst.comms import Connection, LEGO_MOVE_HUB, MOVE_HUB_HW_UUID_CHAR
+from pylgbst.comms import Connection, MOVE_HUB_HW_UUID_CHAR
 from bleak import discover
 from bleak import BleakClient
 from bleak.backends.device import BLEDevice
@@ -17,7 +17,9 @@ req_queue = queue.Queue()
 
 
 class BleakDriver(object):
-
+    """
+    Driver that provides interface between API and Bleak
+    """
     def __init__(self, hub_mac=None):
         self.hub_mac = hub_mac
         self._handler = None
@@ -79,9 +81,9 @@ class BleakDriver(object):
 
 
 class BleakConnection(Connection):
-    def is_alive(self):
-        pass
-
+    """
+    Bleak driver for communicating with BLE device
+    """
     def __init__(self):
         Connection.__init__(self)
         self.loop = asyncio.get_event_loop()
@@ -128,3 +130,6 @@ class BleakConnection(Connection):
             log.debug(f'RSP {handle} {[hex(x) for x in data]}')
             handler(handle, data)
         await self._client.start_notify(MOVE_HUB_HW_UUID_CHAR, c)
+
+    def is_alive(self):
+        pass

--- a/pylgbst/comms/cbleak.py
+++ b/pylgbst/comms/cbleak.py
@@ -1,0 +1,130 @@
+import asyncio
+import logging
+import queue
+import threading
+import time
+
+from pylgbst.comms import Connection, LEGO_MOVE_HUB, MOVE_HUB_HW_UUID_CHAR
+from bleak import discover
+from bleak import BleakClient
+from bleak.backends.device import BLEDevice
+
+log = logging.getLogger('comms-bleak')
+
+# Queues to handle request / responses. Acts as a buffer between API and async BLE driver
+resp_queue = queue.Queue()
+req_queue = queue.Queue()
+
+
+class BleakDriver(object):
+
+    def __init__(self, hub_mac=None):
+        self.hub_mac = hub_mac
+        self._handler = None
+        self._abort = False
+        self._connection_thread = None
+        self._processing_thread = None
+
+    def set_notify_handler(self, handler):
+        self._handler = handler
+
+    def enable_notifications(self):
+        self._connection_thread = threading.Thread(target=lambda: asyncio.run(self._bleak_thread()))
+        self._connection_thread.daemon = True
+        self._connection_thread.start()
+
+        self._processing_thread = threading.Thread(target=self._processing)
+        self._processing_thread.daemon = True
+        self._processing_thread.start()
+
+    async def _bleak_thread(self):
+        bleak = BleakConnection()
+        await bleak.connect(self.hub_mac)
+        await bleak.set_notify_handler(self._safe_handler)
+        # After connecting, need to send any data or hub will drop the connection,
+        # below command is Advertising name request update
+        await bleak.write_char(MOVE_HUB_HW_UUID_CHAR, bytearray([0x05, 0x00, 0x01, 0x01, 0x05]))
+        while not self._abort:
+            await asyncio.sleep(0.1)
+            if req_queue.qsize() != 0:
+                data = req_queue.get()
+                await bleak.write(data[0], data[1])
+
+    @staticmethod
+    def _safe_handler(handler, data):
+        resp_queue.put((handler, data))
+
+    def _processing(self):
+        while not self._abort:
+            if resp_queue.qsize() != 0:
+                msg = resp_queue.get()
+                self._handler(msg[0], msg[1])
+
+            time.sleep(0.1)
+
+    def write(self, handle, data):
+        if not self._connection_thread.is_alive() or not self._processing_thread.is_alive():
+            raise ConnectionError('Something went wrong, communication threads not functioning.')
+
+        req_queue.put((handle, data))
+
+    def disconnect(self):
+        self._abort = True
+
+    def is_alive(self):
+        if self._connection_thread is not None and self._processing_thread is not None:
+            return self._connection_thread.is_alive() and self._processing_thread.is_alive()
+        else:
+            return False
+
+
+class BleakConnection(Connection):
+    def is_alive(self):
+        pass
+
+    def __init__(self):
+        Connection.__init__(self)
+        self.loop = asyncio.get_event_loop()
+
+        self._device: BLEDevice = None
+        self._client: BleakClient = None
+        logging.getLogger('bleak.backends.dotnet.client').setLevel(logging.getLogger().level)
+
+    async def connect(self, hub_mac=None):
+        log.info("Discovering devices... Press Green button on lego MoveHub")
+        devices = await discover()
+        log.debug("Devices: %s", devices)
+
+        for dev in devices:
+            log.debug(dev)
+            address = dev.address
+            name = dev.name
+            if self._is_device_matched(address, name, hub_mac):
+                log.info('DEVICE MATCHED')
+                self._device = dev
+                break
+
+        if not self._device:
+            raise ConnectionError('Device not found.')
+
+        self._client = BleakClient(self._device.address, self.loop)
+        status = await self._client.connect()
+        log.debug(f'Connection status: {status}')
+
+    async def write(self, handle, data):
+        log.debug(f'REQ {handle} {[hex(x) for x in data]}')
+        desc = self._client.services.get_descriptor(handle)
+        if desc is None:
+            # dedicated handle not found, try to send by using LEGO Move Hub default characteristic
+            await self._client.write_gatt_char(MOVE_HUB_HW_UUID_CHAR, data)
+        else:
+            await self._client.write_gatt_char(desc.characteristic_uuid, data)
+
+    async def write_char(self, characteristic_uuid, data):
+        await self._client.write_gatt_char(characteristic_uuid, data)
+
+    async def set_notify_handler(self, handler):
+        def c(handle, data):
+            log.debug(f'RSP {handle} {[hex(x) for x in data]}')
+            handler(handle, data)
+        await self._client.start_notify(MOVE_HUB_HW_UUID_CHAR, c)

--- a/pylgbst/comms/cbleak.py
+++ b/pylgbst/comms/cbleak.py
@@ -16,13 +16,13 @@ req_queue = queue.Queue()
 
 
 class BleakDriver(object):
-    """
-    Driver that provides interface between API and Bleak.
-    """
+
+    """Driver that provides interface between API and Bleak."""
 
     def __init__(self, hub_mac=None):
         """
-        Initialize new object of Bleak Driver class
+        Initialize new object of Bleak Driver class.
+
         :param hub_mac: Optional Lego HUB MAC to connect to.
         """
         self.hub_mac = hub_mac
@@ -33,7 +33,8 @@ class BleakDriver(object):
 
     def set_notify_handler(self, handler):
         """
-        Sets handler function used to communicate with an API
+        Set handler function used to communicate with an API.
+
         :param handler: Handler function called by driver when received data
         :return: None
         """
@@ -41,8 +42,9 @@ class BleakDriver(object):
 
     def enable_notifications(self):
         """
-        Enables notifications, in our cases starts communication threads.
-        We cannot do this earlier, because API need to fist set notification handler
+        Enable notifications, in our cases starts communication threads.
+
+        We cannot do this earlier, because API need to fist set notification handler.
         :return: None
         """
         self._connection_thread = threading.Thread(target=lambda: asyncio.run(self._bleak_thread()))
@@ -80,7 +82,8 @@ class BleakDriver(object):
 
     def write(self, handle, data):
         """
-        Sends data to given handle number.
+        Send data to given handle number.
+
         :param handle: Handle number that will be translated into characteristic uuid
         :param data: data to send
         :raises ConnectionError" When internal threads are not working
@@ -93,7 +96,8 @@ class BleakDriver(object):
 
     def disconnect(self):
         """
-        Disconnects and stops communication threads.
+        Disconnect and stops communication threads.
+
         :return: None
         """
         self._abort = True
@@ -101,6 +105,7 @@ class BleakDriver(object):
     def is_alive(self):
         """
         Indicate whether driver is functioning or not.
+
         :return: True if driver is functioning; False otherwise.
         """
         if self._connection_thread is not None and self._processing_thread is not None:
@@ -110,11 +115,11 @@ class BleakDriver(object):
 
 
 class BleakConnection(Connection):
-    """
-    Bleak driver for communicating with BLE device
-    """
+
+    """Bleak driver for communicating with BLE device."""
+
     def __init__(self):
-        """Initializes new instance of BleakConnection class."""
+        """Initialize new instance of BleakConnection class."""
         Connection.__init__(self)
         self.loop = asyncio.get_event_loop()
 
@@ -124,7 +129,8 @@ class BleakConnection(Connection):
 
     async def connect(self, hub_mac=None):
         """
-        Connects to device
+        Connect to device.
+
         :param hub_mac: Optional Lego HUB MAC to connect to.
         :raises ConnectionError: When cannot connect to given MAC or name matching fails.
         :return: None
@@ -151,7 +157,8 @@ class BleakConnection(Connection):
 
     async def write(self, handle, data):
         """
-        Sends data to given handle number.
+        Send data to given handle number.
+
         If handle cannot be found in service description, hardcoded LEGO uuid will be used.
         :param handle: Handle number that will be translated into characteristic uuid
         :param data: data to send
@@ -167,7 +174,8 @@ class BleakConnection(Connection):
 
     async def write_char(self, characteristic_uuid, data):
         """
-        Sends data to given handle number.
+        Send data to given handle number.
+
         :param characteristic_uuid: Characteristic uuid used to send data
         :param data: data to send
         :return: None
@@ -176,7 +184,8 @@ class BleakConnection(Connection):
 
     async def set_notify_handler(self, handler):
         """
-        Sets notification handler.
+        Set notification handler.
+
         :param handler: Handle function to be called when receive any data.
         :return: None
         """
@@ -188,6 +197,7 @@ class BleakConnection(Connection):
     def is_alive(self):
         """
         To keep compatibility with the driver interface.
+
         This method does nothing.
         :return: None.
         """

--- a/pylgbst/comms/cbleak.py
+++ b/pylgbst/comms/cbleak.py
@@ -7,7 +7,6 @@ import time
 from pylgbst.comms import Connection, MOVE_HUB_HW_UUID_CHAR
 from bleak import discover
 from bleak import BleakClient
-from bleak.backends.device import BLEDevice
 
 log = logging.getLogger('comms-bleak')
 
@@ -18,9 +17,14 @@ req_queue = queue.Queue()
 
 class BleakDriver(object):
     """
-    Driver that provides interface between API and Bleak
+    Driver that provides interface between API and Bleak.
     """
+
     def __init__(self, hub_mac=None):
+        """
+        Initialize new object of Bleak Driver class
+        :param hub_mac: Optional Lego HUB MAC to connect to.
+        """
         self.hub_mac = hub_mac
         self._handler = None
         self._abort = False
@@ -28,9 +32,19 @@ class BleakDriver(object):
         self._processing_thread = None
 
     def set_notify_handler(self, handler):
+        """
+        Sets handler function used to communicate with an API
+        :param handler: Handler function called by driver when received data
+        :return: None
+        """
         self._handler = handler
 
     def enable_notifications(self):
+        """
+        Enables notifications, in our cases starts communication threads.
+        We cannot do this earlier, because API need to fist set notification handler
+        :return: None
+        """
         self._connection_thread = threading.Thread(target=lambda: asyncio.run(self._bleak_thread()))
         self._connection_thread.daemon = True
         self._connection_thread.start()
@@ -65,15 +79,30 @@ class BleakDriver(object):
             time.sleep(0.1)
 
     def write(self, handle, data):
+        """
+        Sends data to given handle number.
+        :param handle: Handle number that will be translated into characteristic uuid
+        :param data: data to send
+        :raises ConnectionError" When internal threads are not working
+        :return: None
+        """
         if not self._connection_thread.is_alive() or not self._processing_thread.is_alive():
             raise ConnectionError('Something went wrong, communication threads not functioning.')
 
         req_queue.put((handle, data))
 
     def disconnect(self):
+        """
+        Disconnects and stops communication threads.
+        :return: None
+        """
         self._abort = True
 
     def is_alive(self):
+        """
+        Indicate whether driver is functioning or not.
+        :return: True if driver is functioning; False otherwise.
+        """
         if self._connection_thread is not None and self._processing_thread is not None:
             return self._connection_thread.is_alive() and self._processing_thread.is_alive()
         else:
@@ -85,14 +114,21 @@ class BleakConnection(Connection):
     Bleak driver for communicating with BLE device
     """
     def __init__(self):
+        """Initializes new instance of BleakConnection class."""
         Connection.__init__(self)
         self.loop = asyncio.get_event_loop()
 
-        self._device: BLEDevice = None
-        self._client: BleakClient = None
+        self._device = None
+        self._client = None
         logging.getLogger('bleak.backends.dotnet.client').setLevel(logging.getLogger().level)
 
     async def connect(self, hub_mac=None):
+        """
+        Connects to device
+        :param hub_mac: Optional Lego HUB MAC to connect to.
+        :raises ConnectionError: When cannot connect to given MAC or name matching fails.
+        :return: None
+        """
         log.info("Discovering devices... Press Green button on lego MoveHub")
         devices = await discover()
         log.debug("Devices: %s", devices)
@@ -102,7 +138,7 @@ class BleakConnection(Connection):
             address = dev.address
             name = dev.name
             if self._is_device_matched(address, name, hub_mac):
-                log.info('DEVICE MATCHED')
+                log.info('Device matched')
                 self._device = dev
                 break
 
@@ -111,10 +147,17 @@ class BleakConnection(Connection):
 
         self._client = BleakClient(self._device.address, self.loop)
         status = await self._client.connect()
-        log.debug(f'Connection status: {status}')
+        log.debug('Connection status: {status}'.format(status=status))
 
     async def write(self, handle, data):
-        log.debug(f'REQ {handle} {[hex(x) for x in data]}')
+        """
+        Sends data to given handle number.
+        If handle cannot be found in service description, hardcoded LEGO uuid will be used.
+        :param handle: Handle number that will be translated into characteristic uuid
+        :param data: data to send
+        :return: None
+        """
+        log.debug('Request: {handle} {payload}'.format(handle=handle, payload=[hex(x) for x in data]))
         desc = self._client.services.get_descriptor(handle)
         if desc is None:
             # dedicated handle not found, try to send by using LEGO Move Hub default characteristic
@@ -123,13 +166,29 @@ class BleakConnection(Connection):
             await self._client.write_gatt_char(desc.characteristic_uuid, data)
 
     async def write_char(self, characteristic_uuid, data):
+        """
+        Sends data to given handle number.
+        :param characteristic_uuid: Characteristic uuid used to send data
+        :param data: data to send
+        :return: None
+        """
         await self._client.write_gatt_char(characteristic_uuid, data)
 
     async def set_notify_handler(self, handler):
+        """
+        Sets notification handler.
+        :param handler: Handle function to be called when receive any data.
+        :return: None
+        """
         def c(handle, data):
-            log.debug(f'RSP {handle} {[hex(x) for x in data]}')
+            log.debug('Response: {handle} {payload}'.format(handle=handle, payload=[hex(x) for x in data]))
             handler(handle, data)
         await self._client.start_notify(MOVE_HUB_HW_UUID_CHAR, c)
 
     def is_alive(self):
+        """
+        To keep compatibility with the driver interface.
+        This method does nothing.
+        :return: None.
+        """
         pass

--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,6 @@ setup(
         "gattlib": ["gattlib"],
         "pygatt": ["pygatt", "pexpect"],
         "bluepy": ["bluepy"],
+        "bleak": ["bleak"],
     },
 )

--- a/tests/test_cbleak.py
+++ b/tests/test_cbleak.py
@@ -1,0 +1,53 @@
+import time
+import unittest
+import pylgbst
+import pylgbst.comms.cbleak as cbleak
+from pylgbst.comms.cbleak import BleakDriver
+
+last_response = None
+
+
+class BleakDriverTest(unittest.TestCase):
+
+    def test_driver_creation(self):
+        connection = pylgbst.get_connection_bleak()
+        self.assertIsInstance(connection, BleakDriver)
+        self.assertFalse(connection.is_alive(), 'Checking that factory returns not started driver')
+
+    def test_communication(self):
+        driver = BleakDriver()
+
+        async def fake_thread():
+            print('Fake thread initialized')
+            while not driver._abort:
+                time.sleep(0.1)
+                if cbleak.req_queue.qsize() != 0:
+                    print('Received data, sending back')
+                    data = cbleak.req_queue.get()
+                    cbleak.resp_queue.put(data)
+
+        driver._bleak_thread = fake_thread
+        driver.set_notify_handler(BleakDriverTest.validation_handler)
+        driver.enable_notifications()
+
+        time.sleep(0.5)   # time for driver initialization
+        self.assertTrue(driver.is_alive(), 'Checking that driver starts')
+        handle = 0x32
+        data = [0xD, 0xE, 0xA, 0xD, 0xB, 0xE, 0xE, 0xF]
+        driver.write(handle, data)
+        time.sleep(0.5)   # processing time
+        self.assertEqual(handle, last_response[0], 'Verifying response handle')
+        self.assertEqual(data, last_response[1], 'Verifying response data')
+
+        driver.disconnect()
+        time.sleep(0.5)   # processing time
+        self.assertFalse(driver.is_alive())
+
+    @staticmethod
+    def validation_handler(handle, data):
+        global last_response
+        last_response = (handle, data)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adding a driver that use Bleak as a underlaying BLE infrastructure.
This enables usage of BLE devices without a need of additional dongle, 
If you have an BLE device in system and Windows see it it can be used for communication.
