### PR TITLE
Fix to work with Bleak on a mac

### DIFF
--- a/pylgbst/comms/cbleak.py
+++ b/pylgbst/comms/cbleak.py
@@ -78,7 +78,7 @@ class BleakDriver(object):
         while not self._abort:
             if resp_queue.qsize() != 0:
                 msg = resp_queue.get()
-                self._handler(msg[0], msg[1])
+                self._handler(msg[0], bytes(msg[1]))
 
             time.sleep(0.01)
         logging.info("Processing thread has exited")


### PR DESCRIPTION
- Sometimes the data returnes is not byte/bytes, but native objective-c class _NSInlineData
  even though isinstance will fail, otherwise it seems to be working