### PR TITLE
Handle failures on port out commands

### DIFF
--- a/pylgbst/messages.py
+++ b/pylgbst/messages.py
@@ -704,7 +704,7 @@ class MsgPortOutput(DownstreamMsg):
 
     def is_reply(self, msg):
         return isinstance(msg, MsgPortOutputFeedback) and msg.port == self.port \
-               and (msg.is_completed() or self.is_buffered)
+            and not (msg.is_in_progress() or msg.is_busy())
 
 
 class MsgPortOutputFeedback(UpstreamMsg):
@@ -735,6 +735,9 @@ class MsgPortOutputFeedback(UpstreamMsg):
 
     def is_idle(self):
         return self.status & 0b1000
+
+    def is_busy(self):
+        return self.status & 0b10000
 
 
 UPSTREAM_MSGS = (


### PR DESCRIPTION
Port out commands can fail (e.x obstruction of the movement), and it
will get the while executon stuck. The diff handles failures and
reports errors to the caller while at it, its useful to know when
the command fails.