### PR TITLE
Headlight support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ If you have Vernie assembled, you might run scripts from [`examples/vernie`](exa
 - [vision sensor](docs/VisionSensor.md): several modes to measure distance, color and luminosity
 - [tilt sensor](docs/TiltSensor.md) subscription: 2 axis, 3 axis, bump detect modes
 - [RGB LED](docs/LED.md) color change
+- [Headlight](docs/Headlight.md) brightness change
 - [push button](docs/MoveHub.md#push-button) status subscription
 - [battery voltage and current](docs/VoltageCurrent.md) subscription available
 

--- a/docs/Headlight.md
+++ b/docs/Headlight.md
@@ -1,0 +1,20 @@
+### Headlight
+
+You can set the brightness of the LEDs of this set using the `LEDLight` class and its
+`set_brightness` method. Accepted values are between 0 and 100%.
+
+Example to make the LEDs blink:
+
+```python
+import time
+from pylgbst.hub import MoveHub
+
+hub = MoveHub()
+# Blink forever
+while True:
+    # Headlight is on port D; set its brightness to 100%
+    hub.port_D.set_brightness(100)
+    time.sleep(1)
+    # Shutdown the ligth
+    hub.port_D.set_brightness(0)
+```

--- a/docs/Peripherals.md
+++ b/docs/Peripherals.md
@@ -4,6 +4,7 @@ Here is the list of peripheral devices that have dedicated classes in library:
 
 - [Motors](Motor.md)
 - [RGB LED](LED.md)
+- [Headlight](Headlight.md)
 - [Tilt Sensor](TiltSensor.md)
 - [Vision Sensor](VisionSensor.md) (color and/or distance)
 - [Voltage and Current Sensors](VoltageCurrent.md)
@@ -19,6 +20,6 @@ It is possible to subscribe with multiple times for the same sensor. Only one, v
 
 Good practice for any program is to unsubscribe from all sensor subscriptions before exiting, especially when used with `DebugServer`.
 
-## Generic Perihpheral 
+## Generic Peripheral
 
 In case you have used a peripheral that is not recognized by the library, it will be detected as generic `Peripheral` class. You still can use subscription and sensor info getting commands for it.  

--- a/pylgbst/hub.py
+++ b/pylgbst/hub.py
@@ -15,6 +15,7 @@ PERIPHERAL_TYPES = {
     DevTypes.MOTOR_INTERNAL_TACHO: EncodedMotor,
     DevTypes.VISION_SENSOR: VisionSensor,
     DevTypes.RGB_LIGHT: LEDRGB,
+    DevTypes.LED_LIGHT: LEDLight,
     DevTypes.TILT_EXTERNAL: TiltSensor,
     DevTypes.TILT_INTERNAL: TiltSensor,
     DevTypes.CURRENT: Current,

--- a/pylgbst/peripherals.py
+++ b/pylgbst/peripherals.py
@@ -239,6 +239,27 @@ class LEDRGB(Peripheral):
             return usbyte(msg.payload, 0),
 
 
+class LEDLight(Peripheral):
+    """Support of headlight kit (LPF2-LIGHT)"""
+    MODE_BRIGHTNESS = 0x00
+
+    def __init__(self, parent, port):
+        super(LEDLight, self).__init__(parent, port)
+
+    def set_brightness(self, brightness):
+        if not isinstance(brightness, (int, float)) or brightness > 100 or brightness < 0:
+            raise ValueError("Brightness must be a number between 0 and 100")
+
+        self.set_port_mode(self.MODE_BRIGHTNESS)
+        payload = pack("<B", self.MODE_BRIGHTNESS) + pack("<B", int(brightness))
+
+        msg = MsgPortOutput(self.port, MsgPortOutput.WRITE_DIRECT_MODE_DATA, payload)
+        self._send_output(msg)
+
+    def _decode_port_data(self, msg):
+        return (usbyte(msg.payload, 0),)
+
+
 class Motor(Peripheral):
     SUBCMD_START_POWER = 0x01
     SUBCMD_START_POWER_GROUPED = 0x02


### PR DESCRIPTION
Hello I propose you in this PR the support of the kit [headlight](https://brickset.com/sets/88005-1/).

The name of the class is `LEDLight` I hope it suits you. Maybe it should be renamed to simply as `Headlight`.

The `_decode_port_data` function is not documented, so I hope it is implemented correctly according to the behavior I assume (return the value according to the current sensor mode).

Maybe you would like to add a shortcut to the `MoveHub` class like the attributes attributes `vision_sensor` and `motor_external`?

PS: Please note that unit test **are not** updated.