### PR TITLE
Doc update

### DIFF
--- a/docs/VisionSensor.md
+++ b/docs/VisionSensor.md
@@ -1,7 +1,6 @@
 ### Color & Distance Sensor
-![](https://img.bricklink.com/ItemImage/PL/6182145.png)
 
- Sensor has number of different modes to subscribe. 
+Sensor has number of different modes to subscribe.
 
 Colors that are detected are part of `COLORS` map (see [LED](#led) section). Only several colors are possible to detect: `BLACK`, `BLUE`, `CYAN`, `YELLOW`, `RED`, `WHITE`. Sensor does its best to detect best color, but only works when sample is very close to sensor.
 
@@ -13,8 +12,8 @@ Simple example of subscribing to sensor:
 from pylgbst.hub import MoveHub, VisionSensor
 import time
 
-def callback(clr, distance):
-    print("Color: %s / Distance: %s" % (clr, distance))
+def callback(color, distance):
+    print("Color: %s / Distance: %s" % (color, distance))
 
 hub = MoveHub()
 

--- a/docs/VisionSensor.md
+++ b/docs/VisionSensor.md
@@ -22,14 +22,15 @@ time.sleep(60) # play with sensor while it waits
 hub.vision_sensor.unsubscribe(callback)
 ```
 
-Subscription mode constants in class `ColorDistanceSensor` are:
-- `COLOR_DISTANCE_FLOAT` - default mode, use `callback(color, distance)` where `distance` is float value in inches
-- `COLOR_ONLY` - use `callback(color)`
+Subscription mode constants in class `VisionSensor` are:
+- `COLOR_INDEX` - use `callback(color)`
 - `DISTANCE_INCHES` - use `callback(color)` measures distance in integer inches count
 - `COUNT_2INCH` - use `callback(count)` - it counts crossing distance ~2 inches in front of sensor
-- `DISTANCE_HOW_CLOSE` - use `callback(value)` - value of 0 to 255 for 30 inches, larger with closer distance
-- `DISTANCE_SUBINCH_HOW_CLOSE` - use `callback(value)` - value of 0 to 255 for 1 inch, larger with closer distance
-- `LUMINOSITY` - use `callback(luminosity)` where `luminosity` is float value from 0 to 1
-- `OFF1` and `OFF2` - seems to turn sensor LED and notifications off
-- `STREAM_3_VALUES` - use `callback(val1, val2, val3)`, sends some values correlating to distance, not well understood at the moment
+- `DISTANCE_REFLECTED` - use `callback(reflected)` where `reflected` is float value from 0 to 1
+- `AMBIENT_LIGHT` - use `callback(luminosity)` where `luminosity` is float value from 0 to 1
+- `COLOR_RGB` - use `callback(red, green, blue)` - each value corresponds to a color channel
+- `COLOR_DISTANCE_FLOAT` - default mode, use `callback(color, distance)` where `distance` is float value in inches
 
+Two specific constants are used with methods to act on the sensor:
+- `set_color(color)` and `SET_COLOR` mode - allow to change the color of the sensor RGBLED. `COLOR_BLACK` and `COLOR_NONE` turns the LED off
+- `set_ir_tx(ir_code)` and `SET_IR_TX` mode - allow to send IR code for PowerFunctions receiver

--- a/docs/VoltageCurrent.md
+++ b/docs/VoltageCurrent.md
@@ -9,6 +9,6 @@ def callback(value):
     print("Voltage: %s" % value)
 
 hub = MoveHub()
-print ("Value L: " % hub.voltage.get_sensor_data(Voltage.VOLTAGE_L))
-print ("Value S: " % hub.voltage.get_sensor_data(Voltage.VOLTAGE_S))
+print ("Value L: %s" % hub.voltage.get_sensor_data(Voltage.VOLTAGE_L))
+print ("Value S: %s" % hub.voltage.get_sensor_data(Voltage.VOLTAGE_S))
 ```

--- a/pylgbst/peripherals.py
+++ b/pylgbst/peripherals.py
@@ -541,7 +541,7 @@ class VisionSensor(Peripheral):
     SET_COLOR = 0x05
     COLOR_RGB = 0x06
     SET_IR_TX = 0x07
-    COLOR_DISTANCE_FLOAT = 0x08  # it's not declared by dev's mode info
+    COLOR_DISTANCE_FLOAT = 0x08
 
     DEBUG = 0x09  # first val is by fact ambient light, second is zero
     CALIBRATE = 0x0a  # gives constant values

--- a/tests/descr.json
+++ b/tests/descr.json
@@ -693,7 +693,7 @@
       "can_input": false
     }
   },
-  "ColorDistanceSensor on port 0x1": {
+  "VisionSensor on port 0x1": {
     "mode_count": 11,
     "input_modes": [
       {


### PR DESCRIPTION
Hello here is a small update of the documentation, especially about the color and distance sensor.
The description of the modes was not up to date.

Accepted values for `set_color` and returned values for `COLOR_INDEX` modes are not quiet documented but it's unclear for me.

First, I don't have this sensor and I don't know if COLOR_INDEX is the detected color by the sensor, or the current color of 
the RGB led.

---

About `set_color`: it appears it accept only BLACK/NONE, RED, GREEN and BLUE according to pybricks:

https://github.com/pybricks/pybricks-micropython/blob/master/pybricks/pupdevices/pb_type_pupdevices_colordistancesensor.c

---

About the detection ability: the official documentation shows "6 colors".
https://brickset.com/sets/88007-1/

Idem in:
https://github.com/JorgePe/BOOSTreveng/blob/master/ColorDistanceSensor.md


I implemented in my own library (https://github.com/ysard/MyOwnBricks) the following colors:

COLOR_NONE     0xFF
COLOR_BLACK    0
COLOR_BLUE     3
COLOR_GREEN    5
COLOR_YELLOW   7
COLOR_RED      9
COLOR_WHITE    10

So there would be an inversion in the naming of the CYAN-GREEN colors here:
https://github.com/undera/pylgbst/blob/6fc3bf4e04367a803b8666f181a9c79c86e386ea/pylgbst/peripherals.py#L19-L20


---

About the distance, I don't think it is represented in inches or cm since the data is supposed to be mapped from 0 to 10.

Source:
https://github.com/pybricks/pybricks-micropython/blob/5bf7d4e49ca084bfab3f8889642867b8c49e7a84/pybricks/pupdevices/pb_type_pupdevices_colordistancesensor.c#L115
and:
https://docs.pybricks.com/en/stable/pupdevices/colordistancesensor.html#pybricks.pupdevices.ColorDistanceSensor.distance

and:
https://github.com/JorgePe/BOOSTreveng/issues/33#issuecomment-426493156

Who is right?


Thanks for reading :p