### PR TITLE
Fix ledrgb getter

### DIFF
--- a/docs/LED.md
+++ b/docs/LED.md
@@ -6,7 +6,44 @@ You can obtain colors are present as constants `COLOR_*` and also a map of avail
 Available constants: `COLOR_BLACK, COLOR_PINK, COLOR_PURPLE, COLOR_BLUE, COLOR_LIGHTBLUE,
 COLOR_CYAN, COLOR_GREEN, COLOR_YELLOW, COLOR_ORANGE, COLOR_RED, COLOR_WHITE, COLOR_NONE`.
 
-Additionally, you can subscribe to LED color change events, using callback function as shown in example below.
+
+LED color can be simply modified:
+```python
+from pylgbst.hub import MoveHub, COLOR_RED
+
+hub = MoveHub()
+print("Set LED color to red:")
+hub.led.color = COLOR_RED
+# or
+hub.led.set_color(COLOR_RED)
+
+print("Set LED color to red, via the RGB value:")
+hub.led.color = (255, 0, 0)
+```
+
+Tip: blinking orange color of LED means battery is low.
+
+Note that the VisionSensor can also be used to set its LED color into indexed
+ colors.
+
+---
+
+Warning: The following doc is experimental; getting data from the LED peripheral
+doesn't currently produce meaningful results (0 values both with MODE_INDEX or
+ MODE_RGB). Indeed, the callback is no longer issued when the color changes.
+
+You can access to the current color as shown in the example:
+
+```python
+from pylgbst.hub import MoveHub
+from pylgbst.peripherals import LEDRGB
+hub = MoveHub()
+print("Current color - mode INDEX", hub.led.get_sensor_data(LEDRGB.MODE_INDEX))
+print("Current color - mode RGB", hub.led.get_sensor_data(LEDRGB.MODE_RGB))
+```
+
+Additionally, you can subscribe to LED color change events, using callback function
+as shown in example below.
 
 ```python
 from pylgbst.hub import MoveHub, COLORS, COLOR_NONE, COLOR_RED
@@ -26,18 +63,3 @@ for color in COLORS:
 hub.led.set_color(COLOR_NONE)
 hub.led.unsubscribe(callback)
 ```
-
-Colors can be modified or obtained via simple properties:
-```python
-from pylgbst.hub import MoveHub, COLOR_RED
-
-hub = MoveHub()
-print("Current color:", hub.led.color)
-print("Set LED color to red:")
-hub.led.color = COLOR_RED
-```
-
-Tip: blinking orange color of LED means battery is low.
-
-
-Note that Vision Sensor can also be used to set its LED color into indexed colors.

--- a/pylgbst/peripherals.py
+++ b/pylgbst/peripherals.py
@@ -263,26 +263,18 @@ class LEDRGB(Peripheral):
         msg = MsgPortOutput(self.port, MsgPortOutput.WRITE_DIRECT_MODE_DATA, payload)
         self._send_output(msg)
 
-    @property
-    def color(self):
-        """Get color as RGB, or index form
-
-        The type of data depends of the data set (RGB: tuple of 3 values,
-        index: tuple of 1 value); default mode is "index".
-        """
-        return self.get_sensor_data(
-            self._port_mode.mode if self._port_mode.mode else self.MODE_INDEX
-        )
-
-    @color.setter
-    def color(self, color):
-        """Set color of the RGB LED
-
-        .. seealso: `set_color`
-        """
-        self.set_color(color)
-
     def _decode_port_data(self, msg):
+        """Decode data emitted by the hub
+
+        .. note:: Experimental function for now; Most of the time, hardware
+            shouldn't return any data. Also note that its seems not possible
+            to retrieve the current RGB color on the peripheral.
+            See issue #111.
+
+        :param msg: Message retrieved from the hub.
+        :return: Tuple of length dependent of the current mode (1 for MODE_INDEX,
+            3 for MODE_RGB)
+        """
         if len(msg.payload) == 3:
             return (
                 usbyte(msg.payload, 0),
@@ -291,6 +283,9 @@ class LEDRGB(Peripheral):
             )
         else:
             return (usbyte(msg.payload, 0),)
+
+    # Set color of the RGB LED (no getter)
+    color = property(fset=set_color)
 
 
 class LEDLight(Peripheral):


### PR DESCRIPTION
According to the #111 discussion:
- Removed getter property for current color
- Setter property stays in place
- Doc is updated, the callback/access to current color examples are moved to the end with a disclaimer