### PR TITLE
Allow non-blocking motor operations (#49)

### DIFF
--- a/docs/Motor.md
+++ b/docs/Motor.md
@@ -6,11 +6,14 @@
 
 Methods to activate motors are:
 - `start_speed(speed_primary, speed_secondary)` - enables motor with specified speed forever 
-- `timed(time, speed_primary, speed_secondary)` - enables motor with specified speed for `time` seconds, float values accepted
-- `angled(angle, speed_primary, speed_secondary)` - makes motor to rotate to specified angle, `angle` value is integer degrees, can be negative and can be more than 360 for several rounds
+- `timed(time, speed_primary, speed_secondary, wait_complete)` - enables motor with specified speed for `time` seconds, float values accepted
+- `angled(angle, speed_primary, speed_secondary, wait_complete)` - makes motor to rotate to specified angle, `angle` value is integer degrees, can be negative and can be more than 360 for several rounds
 - `stop()` - stops motor
+- `wait_complete()` - waits until the latest operation sent to the motor is complete
 
-Parameter `speed_secondary` is used when it is motor group of `motor_AB` running together. By default, `speed_secondary` equals `speed_primary`. 
+Parameter `speed_secondary` is used when it is motor group of `motor_AB` running together. By default, `speed_secondary` equals `speed_primary`.
+
+Parameter `wait_complete` controls whether a given call blocks execution until the operation has completed. By default, `wait_complete` is `True`.
 
 Speed values range is `-1.0` to `1.0`, float values. _Note: In group angled mode, total rotation angle is distributed across 2 motors according to motor speeds ratio, see official doc [here](https://lego.github.io/lego-ble-wireless-protocol-docs/index.html#tacho-math)._
 
@@ -35,6 +38,17 @@ time.sleep(2)
 hub.motor_external.stop()
 ```
 
+Example usage of non-blocking calls to rotate 2 independent motors in parallel:
+```python
+from pylgbst.hub import MoveHub
+
+hub = MoveHub()
+
+hub.motor_A.timed(0.5, 0.8, wait_complete=False)
+hub.motor_B.angled(90, 0.8, wait_complete=False)
+hub.motor_A.wait_complete()
+hub.motor_B.wait_complete()
+```
 
 ## Motor Rotation Sensors
 

--- a/pylgbst/messages.py
+++ b/pylgbst/messages.py
@@ -745,11 +745,12 @@ class MsgPortOutput(DownstreamMsg):
     WRITE_DIRECT = 0x50
     WRITE_DIRECT_MODE_DATA = 0x51
 
-    def __init__(self, port, subcommand, params):
+    def __init__(self, port, subcommand, params, wait_complete=True):
         super().__init__()
         self.port = port
         self.is_buffered = False
         self.do_feedback = True
+        self.wait_complete = wait_complete
         self.subcommand = subcommand
         self.params = params
 
@@ -774,7 +775,9 @@ class MsgPortOutput(DownstreamMsg):
         return (
             isinstance(msg, MsgPortOutputFeedback)
             and msg.port == self.port
-            and (msg.is_completed() or self.is_buffered)
+            and (not self.wait_complete and msg.is_in_progress() or
+                 msg.is_completed() or
+                 self.is_buffered)
         )
 
 


### PR DESCRIPTION
Allow simple parallelism between independent motors by introducing a
`wait_complete` parameter to long operations (ex. timed and angled
calls).

By default `wait_complete` is true, motor calls are blocking.

Users can explicitly pass `wait_complete=False` into a call to
request non-blocking behavior. In this case the call returns as
soon as the command has been sent to the hub.

A new API call `motor.wait_complete()` can be used to block until
completion of an operation originally requested as non-blocking.