### PR TITLE
comms: fix connect call for linux

### DIFF
--- a/pylgbst/comms/cbleak.py
+++ b/pylgbst/comms/cbleak.py
@@ -59,7 +59,7 @@ class BleakDriver:
     async def _bleak_thread(self):
         bleak = BleakConnection()
         # For MacOS 12+ the service_uuids kwarg is required for scanning
-        kwargs = None
+        kwargs = {}
         if "Darwin" == platform.system() and int(platform.mac_ver()[0].split(".")[0]) >= 12:
             kwargs = {"service_uuids" : [MOVE_HUB_HW_UUID_SERV]}
         await bleak.connect(self.hub_mac, self.hub_name, **kwargs)


### PR DESCRIPTION
When trying to use pylgbst with bleak backend, connection would fail
with the following error:
TypeError: connect() argument after ** must be a mapping, not NoneType

This patch fixes the issue changing None to empty dict.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@gmail.com>